### PR TITLE
Update Diff.rb

### DIFF
--- a/ruby/Diff.rb
+++ b/ruby/Diff.rb
@@ -20,7 +20,7 @@ class Diff
   def compose()
     offset = @m + 1
     delta  = @n - @m
-    size   = @m + @m + 3
+    size   = @m + @n + 3
     fp     = Array.new(size){|i| -1}
     p      = -1
     begin


### PR DESCRIPTION
a  = "Some example."
b = "Some example. Example of script that will get an error" diff = Diff.new(a, b);

The script above was giving an error. The problem was solved by correcting the length measurements in the code that would disrupt the algorithm.